### PR TITLE
merlin-extends' public name is merlin{_,-}extend

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -6,7 +6,7 @@
  (modules imandra_merlin_ocaml)
  (package imandra-merlin)
  (modes byte)
- (libraries compiler-libs.common merlin_extend ocaml-migrate-parsetree imandra-base.syntax)
+ (libraries compiler-libs.common merlin-extend ocaml-migrate-parsetree imandra-base.syntax)
 )
 
 
@@ -16,5 +16,5 @@
  (modules imandra_merlin_reason)
  (package imandra-merlin)
  (modes byte)
- (libraries compiler-libs.common merlin_extend ocaml-migrate-parsetree imandra-base.syntax imandra-reason-parser)
+ (libraries compiler-libs.common merlin-extend ocaml-migrate-parsetree imandra-base.syntax imandra-reason-parser)
 )


### PR DESCRIPTION
I hit this earlier trying to install imandra-merlin to my switch:

```#=== ERROR while compiling imandra-merlin.0.2 =================================#
# context     2.1.0~alpha | linux/x86_64 |  | pinned(git+ssh://git@github.com/aestheticintegration/imandra-merlin.git#93ea48273c4d4b35ebf03c63021e0d0fa13b8a3f#93ea4827)
# path        ~/dev/ai/ipl-worker/_opam/.opam-switch/build/imandra-merlin.0.2
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build @install -p imandra-merlin
# exit-code   1
# env-file    ~/.opam/log/imandra-merlin-10441-487c34.env
# output-file ~/.opam/log/imandra-merlin-10441-487c34.out
### output ###
# File "src/dune", line 9, characters 33-46:
# 9 |  (libraries compiler-libs.common merlin_extend ocaml-migrate-parsetree imandra-base.syntax)
#                                      ^^^^^^^^^^^^^
# Error: Library "merlin_extend" not found.
# Hint: try: dune external-lib-deps --missing -p imandra-merlin @install
# File "src/dune", line 19, characters 33-46:
# 19 |  (libraries compiler-libs.common merlin_extend ocaml-migrate-parsetree imandra-base.syntax imandra-reason-parser)
#                                       ^^^^^^^^^^^^^
# Error: Library "merlin_extend" not found.
# Hint: try: dune external-lib-deps --missing -p imandra-merlin @install```

Changing it to a hyphen seems to fix it - not completely sure why but I think merlin-extend was doing some `META` weirdness originally and it has been removed in newer versions:

https://github.com/let-def/merlin-extend/commit/fbdc8a8bf0c34e8c7ea1080a6eea62089523a312